### PR TITLE
Even More Fixes For Compiler Warnings

### DIFF
--- a/engines/hpl1/engine/game/SaveGame.h
+++ b/engines/hpl1/engine/game/SaveGame.h
@@ -28,6 +28,7 @@
 #ifndef HPL_SAVE_GAME_H
 #define HPL_SAVE_GAME_H
 
+#include <cassert>
 #include <map>
 
 #include "hpl1/engine/system/SerializeClass.h"
@@ -37,16 +38,18 @@ class TiXmlElement;
 
 #define kSaveData_LoadFromBegin(aClass)  \
 	super::LoadFromSaveData(apSaveData); \
-	cSaveData_##aClass *pData = static_cast<cSaveData_##aClass *>(apSaveData);
+	cSaveData_##aClass *pData = static_cast<cSaveData_##aClass *>(apSaveData); \
+	assert(pData != nullptr);
 
 #define kSaveData_SaveToBegin(aClass)  \
 	super::SaveToSaveData(apSaveData); \
-	cSaveData_##aClass *pData = static_cast<cSaveData_##aClass *>(apSaveData);
+	cSaveData_##aClass *pData = static_cast<cSaveData_##aClass *>(apSaveData); \
+	assert(pData != nullptr);
 
 #define kSaveData_SetupBegin(aClass)                                           \
 	super::SaveDataSetup(apSaveObjectHandler, apGame);                         \
 	cSaveData_##aClass *pData = static_cast<cSaveData_##aClass *>(mpSaveData); \
-	(void)pData;
+	assert(pData != nullptr);
 
 #define kSaveData_BaseClass(aClass) class cSaveData_##aClass : public iSaveData
 #define kSaveData_ChildClass(aParent, aChild) class cSaveData_##aChild : public cSaveData_##aParent

--- a/engines/hpl1/engine/graphics/ParticleEmitter3D.cpp
+++ b/engines/hpl1/engine/graphics/ParticleEmitter3D.cpp
@@ -118,7 +118,7 @@ iParticleEmitter3D::~iParticleEmitter3D() {
 void iParticleEmitter3D::SetSubDivUV(const cVector2l &avSubDiv) {
 	// Check so that there is any subdivision and that no sub divison axis is
 	// equal or below zero
-	if ((avSubDiv.x > 1 || avSubDiv.x > 1) && (avSubDiv.x > 0 && avSubDiv.y > 0)) {
+	if ((avSubDiv.x > 1 || avSubDiv.y > 1) && (avSubDiv.x > 0 && avSubDiv.y > 0)) {
 		int lSubDivNum = avSubDiv.x * avSubDiv.y;
 
 		mvSubDivUV.resize(lSubDivNum);

--- a/engines/hpl1/engine/libraries/newton/physics/dgCollision.h
+++ b/engines/hpl1/engine/libraries/newton/physics/dgCollision.h
@@ -176,7 +176,7 @@ typedef void(dgApi *OnDebugCollisionMeshCallback)(void *userData, int vertexCoun
 class dgCollisionBoundPlaneCache {
 public:
 	dgCollisionBoundPlaneCache() {
-		memset(m_planes, 0, sizeof(m_planes));
+		for (uint i = 0; i < sizeof(m_planes)/sizeof(m_planes[0]); i++) m_planes[i] = dgPlane(0.0, 0.0, 0.0, 0.0);
 	}
 	dgPlane m_planes[2];
 };

--- a/engines/hpl1/engine/physics/Collider2D.cpp
+++ b/engines/hpl1/engine/physics/Collider2D.cpp
@@ -73,7 +73,7 @@ tFlag cCollider2D::CollideBody(cBody2D *apBody, cCollideData2D *apData) {
 
 	/////// TEST COLLISION WITH TILES
 	float fTileSize = mpWorld->GetTileMap()->GetTileSize();
-	cRect2f TileRect = cRect2f(0, 0, fTileSize, fTileSize);
+	//cRect2f TileRect = cRect2f(0, 0, fTileSize, fTileSize);
 
 	for (int i = 0; i < mpWorld->GetTileMap()->GetTileLayerNum(); i++) {
 		if (mpWorld->GetTileMap()->GetTileLayer(i)->HasCollision() == false)
@@ -83,8 +83,8 @@ tFlag cCollider2D::CollideBody(cBody2D *apBody, cCollideData2D *apData) {
 
 		while (pTileIt->HasNext()) {
 			cTile *pTile = pTileIt->Next();
-			TileRect.x = pTile->GetPosition().x - fTileSize / 2;
-			TileRect.y = pTile->GetPosition().y - fTileSize / 2;
+			//TileRect.x = pTile->GetPosition().x - fTileSize / 2;
+			//TileRect.y = pTile->GetPosition().y - fTileSize / 2;
 
 			// This can be used for material properties.
 			// cTileDataNormal *pTData = static_cast<cTileDataNormal*>(pTile->GetTileData());
@@ -219,7 +219,7 @@ tFlag cCollider2D::CollideRect(cRect2f &aRect, tFlag alCollideFlags, cCollideDat
 	//// Check for all tiles if the flag is set
 	if (alCollideFlags & eFlagBit_0) {
 		float fTileSize = mpWorld->GetTileMap()->GetTileSize();
-		cRect2f TileRect = cRect2f(0, 0, fTileSize, fTileSize);
+		//cRect2f TileRect = cRect2f(0, 0, fTileSize, fTileSize);
 
 		for (int i = 0; i < mpWorld->GetTileMap()->GetTileLayerNum(); i++) {
 			if (mpWorld->GetTileMap()->GetTileLayer(i)->HasCollision() == false)
@@ -229,8 +229,8 @@ tFlag cCollider2D::CollideRect(cRect2f &aRect, tFlag alCollideFlags, cCollideDat
 
 			while (pTileIt->HasNext()) {
 				cTile *pTile = pTileIt->Next();
-				TileRect.x = pTile->GetPosition().x - fTileSize / 2;
-				TileRect.y = pTile->GetPosition().y - fTileSize / 2;
+				//TileRect.x = pTile->GetPosition().x - fTileSize / 2;
+				//TileRect.y = pTile->GetPosition().y - fTileSize / 2;
 
 				if (pTile->GetCollisionMesh() == NULL)
 					continue;

--- a/engines/hpl1/engine/physics/PhysicsWorld.cpp
+++ b/engines/hpl1/engine/physics/PhysicsWorld.cpp
@@ -82,7 +82,7 @@ void iPhysicsWorld::Update(float afTimeStep) {
 
 	////////////////////////////////////
 	// Update character bodies
-	unsigned int lTime = GetApplicationTime();
+	//unsigned int lTime = GetApplicationTime();
 	tCharacterBodyListIt CharIt = mlstCharBodies.begin();
 	for (; CharIt != mlstCharBodies.end(); ++CharIt) {
 		iCharacterBody *pBody = *CharIt;
@@ -105,7 +105,7 @@ void iPhysicsWorld::Update(float afTimeStep) {
 
 	////////////////////////////////////
 	// Simulate the physics
-	lTime = GetApplicationTime();
+	//lTime = GetApplicationTime();
 	Simulate(afTimeStep);
 	// LogUpdate(" Updating lowlevel physics took %d ms\n",mpWorld3D->GetSystem()->GetLowLevel()->GetTime() - lTime);
 

--- a/engines/hpl1/penumbra-overture/Player.cpp
+++ b/engines/hpl1/penumbra-overture/Player.cpp
@@ -976,7 +976,7 @@ cTempCheckProxy gTempCheckProxy;
 
 void cPlayer::Update(float afTimeStep) {
 	cSystem *pSystem = mpInit->mpGame->GetSystem();
-	unsigned int lTime = pSystem->GetLowLevel()->getTime();
+	//unsigned int lTime = pSystem->GetLowLevel()->getTime();
 	iPhysicsWorld *pPhysicsWorld = mpScene->GetWorld3D()->GetPhysicsWorld();
 
 	/////////////////////////////////////
@@ -1014,7 +1014,7 @@ void cPlayer::Update(float afTimeStep) {
 	}
 	//LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);*/
 
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  misc\n");
 	//////////////////////
 	// Reset roll
@@ -1035,28 +1035,28 @@ void cPlayer::Update(float afTimeStep) {
 	/////////////////////////////////////////////////
 	// Flashlight
 	// LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  flashlight");
 	mpFlashLight->Update(afTimeStep);
 
 	/////////////////////////////////////////////////
 	// Glowstick
 	// LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  glowstick\n");
 	mpGlowStick->Update(afTimeStep);
 
 	/////////////////////////////////////////////////
 	// Flare
 	// LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  flare\n");
 	mpFlare->Update(afTimeStep);
 
 	/////////////////////////////////////////////////
 	// Lean
 	// LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  more misc\n");
 	mpLean->Update(afTimeStep);
 
@@ -1083,12 +1083,12 @@ void cPlayer::Update(float afTimeStep) {
 	////////////////////////////////////////
 	// Hidden
 	// LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  hidden\n");
 	mpHidden->Update(afTimeStep);
 
 	// LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  collide scripts\n");
 	/////////////////////////////////////////////////
 	// Collide script
@@ -1189,7 +1189,7 @@ void cPlayer::Update(float afTimeStep) {
 		mlGroundCount--;
 
 	// LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  Check For ground\n");
 	//////////////////////////////
 	// Cast ray and check for ground.
@@ -1205,7 +1205,7 @@ void cPlayer::Update(float afTimeStep) {
 	//////////////////////////////
 	// Update movement
 	// LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  Movement\n");
 
 	if (mbMoving == false)
@@ -1219,7 +1219,7 @@ void cPlayer::Update(float afTimeStep) {
 	//////////////////////////////
 	// Update camera pos add
 	// LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  Camera pos\n");
 	if (mpCharBody) {
 		float fYAdd = mfCameraHeightAdd + mpHeadMove->GetPos() + mfHeightAdd + mpDeath->GetHeighAdd() +
@@ -1245,7 +1245,7 @@ void cPlayer::Update(float afTimeStep) {
 	SetPickedBody(NULL);
 
 	// LogUpdate("  took %d ms\n",pSystem->GetLowLevel()->GetTime() - lTime);
-	lTime = pSystem->GetLowLevel()->getTime();
+	//lTime = pSystem->GetLowLevel()->getTime();
 	// LogUpdate("  state %d\n",mState);
 	if (mpInit->mpInventory->IsActive() == false &&
 		mpInit->mpNotebook->IsActive() == false) {


### PR DESCRIPTION
@grisenti : Some more fixes. Most of these are for compiler warnings including my version of the fix for the Savegame Header Macro unused variable which I noted @sev- submitted a fix to earlier. There are several warnings now which look "real". I have included a fix for one of them which looks to be a cut and paste error in the ParticleEmitter3D code which causes a duplicated check and hence a warning... There are also a large amount of cast qualifier lost i.e. -Wcast-qual. These are mainly in the Newton code included and are related to loss of const from pointers. These are generally harder to fix without rewriting / major restructure of code, but will see.

This is all of my fixes from my local tree so far... still around 5000 lines of warnings to look through. One other one which looks real which I haven't fixed is:
````
engines/hpl1/engine/graphics/ParticleEmitter3D_UserData.cpp: In member function ‘virtual void hpl::cParticleEmitter3D_UserData::SetParticleDefaults(hpl::cParticle*)’:
engines/hpl1/engine/graphics/ParticleEmitter3D_UserData.cpp:774:21: warning: operation on ‘apParticle->hpl::cParticle::mfSpin’ may be undefined [-Wsequence-point]
  apParticle->mfSpin = apParticle->mfSpin = cMath::RandRectf(0.0f, k2Pif);
````
Might be another original code cut and paste whoops.