### PR TITLE
Additional Fixes For Compiler Warnings

### DIFF
--- a/engines/hpl1/engine/libraries/newton/Newton.cpp
+++ b/engines/hpl1/engine/libraries/newton/Newton.cpp
@@ -2889,12 +2889,10 @@ NewtonbreakableComponentMesh *NewtonBreakableGetMainMesh(
 
 void NewtonBreakableBeginDelete(const NewtonCollision *const compoundBreakable) {
 	dgCollision *collision;
-	NewtonbreakableComponentMesh *mesh;
 
 	TRACE_FUNTION(__FUNCTION__);
 	collision = (dgCollision *)compoundBreakable;
 
-	mesh = NULL;
 	if (collision->IsType(dgCollision::dgCollisionCompoundBreakable_RTTI)) {
 		dgCollisionCompoundBreakable *compound;
 		compound = (dgCollisionCompoundBreakable *)collision;
@@ -2907,12 +2905,10 @@ NewtonBody *NewtonBreakableCreateDebrieBody(
 	const NewtonbreakableComponentMesh *const component) {
 	dgBody *body;
 	dgCollision *collision;
-	NewtonbreakableComponentMesh *mesh;
 
 	TRACE_FUNTION(__FUNCTION__);
 	collision = (dgCollision *)compoundBreakable;
 
-	mesh = NULL;
 	body = NULL;
 	if (collision->IsType(dgCollision::dgCollisionCompoundBreakable_RTTI)) {
 		dgCollisionCompoundBreakable *compound;
@@ -2928,12 +2924,10 @@ void NewtonBreakableDeleteComponent(
 	const NewtonCollision *const compoundBreakable,
 	const NewtonbreakableComponentMesh *const component) {
 	dgCollision *collision;
-	NewtonbreakableComponentMesh *mesh;
 
 	TRACE_FUNTION(__FUNCTION__);
 	collision = (dgCollision *)compoundBreakable;
 
-	mesh = NULL;
 	if (collision->IsType(dgCollision::dgCollisionCompoundBreakable_RTTI)) {
 		dgCollisionCompoundBreakable *compound;
 		compound = (dgCollisionCompoundBreakable *)collision;
@@ -2944,12 +2938,10 @@ void NewtonBreakableDeleteComponent(
 
 void NewtonBreakableEndDelete(const NewtonCollision *const compoundBreakable) {
 	dgCollision *collision;
-	NewtonbreakableComponentMesh *mesh;
 
 	TRACE_FUNTION(__FUNCTION__);
 	collision = (dgCollision *)compoundBreakable;
 
-	mesh = NULL;
 	if (collision->IsType(dgCollision::dgCollisionCompoundBreakable_RTTI)) {
 		dgCollisionCompoundBreakable *compound;
 		compound = (dgCollisionCompoundBreakable *)collision;

--- a/engines/hpl1/engine/libraries/newton/core/dgPolyhedra.cpp
+++ b/engines/hpl1/engine/libraries/newton/core/dgPolyhedra.cpp
@@ -3166,6 +3166,7 @@ dgEdge* dgPolyhedra::TriangulateFace(dgEdge* face, const dgFloat64* const pool,
     dgInt32 stride, dgDownHeap<dgEdge*, dgFloat64>& heap
     , dgBigVector* const faceNormalOut)
 {
+#if 0
   dgEdge* perimeter[1024 * 16];
   dgEdge* ptr = face;
   dgInt32 perimeterCount = 0;
@@ -3178,6 +3179,7 @@ dgEdge* dgPolyhedra::TriangulateFace(dgEdge* face, const dgFloat64* const pool,
   } while (ptr != face);
   perimeter[perimeterCount] = face;
   _ASSERTE((perimeterCount + 1) < dgInt32 (sizeof (perimeter) / sizeof (perimeter[0])));
+#endif
 
   dgBigVector normal(
       FaceNormal(face, pool, dgInt32(stride * sizeof(dgFloat64))));

--- a/engines/hpl1/engine/libraries/newton/physics/dgCollisionChamferCylinder.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgCollisionChamferCylinder.cpp
@@ -184,12 +184,10 @@ void dgCollisionChamferCylinder::DebugCollision(const dgMatrix &matrixPtr,
 	dgFloat32 sliceStep;
 	dgFloat32 sliceAngle;
 	dgFloat32 breakStep;
-	dgFloat32 breakAngle;
 
 	slices = 12;
 	brakes = 24;
 	sliceAngle = dgFloat32(0.0f);
-	breakAngle = dgFloat32(0.0f);
 	sliceStep = dgPI / slices;
 	breakStep = dgPI2 / brakes;
 

--- a/engines/hpl1/engine/libraries/newton/physics/dgCollisionCompoundBreakable.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgCollisionCompoundBreakable.cpp
@@ -467,12 +467,10 @@ dgCollisionCompoundBreakable::dgDebriGraph::~dgDebriGraph() {
 
 void dgCollisionCompoundBreakable::dgDebriGraph::Serialize(dgSerialize callback,
 														   void *const userData) const {
-	dgInt32 lru;
 	dgInt32 index;
 	dgInt32 count;
 	dgTree<dgInt32, dgListNode *> enumerator(GetAllocator());
 
-	lru = 0;
 	index = 1;
 	count = GetCount();
 	callback(userData, &count, dgInt32(sizeof(dgInt32)));
@@ -612,9 +610,9 @@ void dgCollisionCompoundBreakable::dgDebriGraph::AddMeshes(
 	dgFloat32 padding) {
 	// padding = 0.0f;
 
-	dgGraph<dgDebriNodeInfo, dgSharedNodeMesh>::dgListNode *fixNode;
+	//dgGraph<dgDebriNodeInfo, dgSharedNodeMesh>::dgListNode *fixNode;
 
-	fixNode = dgGraph<dgDebriNodeInfo, dgSharedNodeMesh>::AddNode();
+	/*fixNode =*/ dgGraph<dgDebriNodeInfo, dgSharedNodeMesh>::AddNode();
 	for (dgInt32 i = 0; i < count; i++) {
 		AddNode(vertexArray, (dgMeshEffect *)solidArray[i], internalFaceMaterial[i],
 				idArray[i], densities[i], padding);

--- a/engines/hpl1/engine/libraries/newton/physics/dgMinkowskiConv.cpp
+++ b/engines/hpl1/engine/libraries/newton/physics/dgMinkowskiConv.cpp
@@ -4018,7 +4018,6 @@ class dgContactSolver {
 
 		dgFloat32 dist;
 		dgFloat32 minValue;
-		dgFloat32 penetration;
 		dgFloat32 ciclingMem[4];
 		dgMinkFace *face;
 		dgMinkFace *adjacent;
@@ -4039,7 +4038,6 @@ class dgContactSolver {
 		m_planeIndex = 4;
 		closestFace = NULL;
 		m_facePurge = NULL;
-		penetration = dgFloat32(0.0f);
 
 		_ASSERTE(m_vertexIndex == 4);
 		for (i = 0; i < 4; i++) {
@@ -4330,7 +4328,6 @@ class dgContactSolver {
 
 		dgFloat64 dist;
 		dgFloat64 minValue;
-		dgFloat64 penetration;
 		dgFloat64 ciclingMem[4];
 		dgMinkFace *face;
 		dgMinkFace *adjacent;
@@ -4351,7 +4348,6 @@ class dgContactSolver {
 		m_planeIndex = 4;
 		closestFace = NULL;
 		m_facePurge = NULL;
-		penetration = dgFloat64(0.0f);
 
 		_ASSERTE(m_vertexIndex == 4);
 		for (i = 0; i < 4; i++) {
@@ -7012,21 +7008,15 @@ dgInt32 dgWorld::CalculatePolySoupToSphereContactsDescrete(
 	dgInt32 indexCount;
 	dgInt32 reduceContactCountLimit;
 	dgFloat32 radius;
-	dgBody *soupBody;
-	dgBody *spheBody;
 	dgCollisionSphere *sphere;
 	dgCollisionMesh *polysoup;
 	dgCollisionMesh::dgCollisionConvexPolygon *polygon;
 	dgVector point;
 
 	count = 0;
-	_ASSERTE(
-		proxy.m_referenceCollision->IsType(dgCollision::dgCollisionSphere_RTTI));
-	_ASSERTE(
-		proxy.m_floatingCollision->IsType(dgCollision::dgCollisionMesh_RTTI));
+	_ASSERTE(proxy.m_referenceCollision->IsType(dgCollision::dgCollisionSphere_RTTI));
+	_ASSERTE(proxy.m_floatingCollision->IsType(dgCollision::dgCollisionMesh_RTTI));
 
-	spheBody = proxy.m_referenceBody;
-	soupBody = proxy.m_floatingBody;
 	sphere = (dgCollisionSphere *)proxy.m_referenceCollision;
 	polysoup = (dgCollisionMesh *)proxy.m_floatingCollision;
 
@@ -7129,21 +7119,15 @@ dgInt32 dgWorld::CalculatePolySoupToElipseContactsDescrete(
 	dgInt32 indexCount;
 	dgInt32 reduceContactCountLimit;
 	dgFloat32 radius;
-	dgBody *soupBody;
-	dgBody *spheBody;
 	dgCollisionEllipse *sphere;
 	dgCollisionMesh *polysoup;
 	dgCollisionMesh::dgCollisionConvexPolygon *polygon;
 	dgVector point;
 
 	count = 0;
-	_ASSERTE(
-		proxy.m_referenceCollision->IsType(dgCollision::dgCollisionEllipse_RTTI));
-	_ASSERTE(
-		proxy.m_floatingCollision->IsType(dgCollision::dgCollisionMesh_RTTI));
+	_ASSERTE(proxy.m_referenceCollision->IsType(dgCollision::dgCollisionEllipse_RTTI));
+	_ASSERTE(proxy.m_floatingCollision->IsType(dgCollision::dgCollisionMesh_RTTI));
 
-	spheBody = proxy.m_referenceBody;
-	soupBody = proxy.m_floatingBody;
 	sphere = (dgCollisionEllipse *)proxy.m_referenceCollision;
 	polysoup = (dgCollisionMesh *)proxy.m_floatingCollision;
 
@@ -7259,8 +7243,6 @@ dgInt32 dgWorld::CalculatePolySoupToSphereContactsContinue (dgCollisionParamProx
   dgFloat32 radius;
   dgInt32* indexArray;
   dgInt32* idArray;
-  dgBody* soupBody;
-  dgBody* spheBody;
   dgCollisionSphere *sphere;
   dgContactPoint* contactOut;
   dgCollisionMesh *polysoup;
@@ -7268,13 +7250,9 @@ dgInt32 dgWorld::CalculatePolySoupToSphereContactsContinue (dgCollisionParamProx
 
   count = 0;
 
-  _ASSERTE(
-	  proxy.m_referenceCollision->IsType (dgCollision::dgCollisionSphere_RTTI));
-  _ASSERTE(
-	  proxy.m_floatingCollision->IsType (dgCollision::dgCollisionMesh_RTTI));
+  _ASSERTE(proxy.m_referenceCollision->IsType (dgCollision::dgCollisionSphere_RTTI));
+  _ASSERTE(proxy.m_floatingCollision->IsType (dgCollision::dgCollisionMesh_RTTI));
 
-  spheBody = proxy.m_referenceBody;
-  soupBody = proxy.m_floatingBody;
   sphere = (dgCollisionSphere*) proxy.m_referenceCollision;
   polysoup = (dgCollisionMesh *) proxy.m_floatingCollision;
 

--- a/engines/hpl1/engine/physics/Collider2D.cpp
+++ b/engines/hpl1/engine/physics/Collider2D.cpp
@@ -72,7 +72,7 @@ tFlag cCollider2D::CollideBody(cBody2D *apBody, cCollideData2D *apData) {
 	cVector2f vLastPushVector;
 
 	/////// TEST COLLISION WITH TILES
-	float fTileSize = mpWorld->GetTileMap()->GetTileSize();
+	//float fTileSize = mpWorld->GetTileMap()->GetTileSize();
 	//cRect2f TileRect = cRect2f(0, 0, fTileSize, fTileSize);
 
 	for (int i = 0; i < mpWorld->GetTileMap()->GetTileLayerNum(); i++) {
@@ -218,7 +218,7 @@ tFlag cCollider2D::CollideRect(cRect2f &aRect, tFlag alCollideFlags, cCollideDat
 
 	//// Check for all tiles if the flag is set
 	if (alCollideFlags & eFlagBit_0) {
-		float fTileSize = mpWorld->GetTileMap()->GetTileSize();
+		//float fTileSize = mpWorld->GetTileMap()->GetTileSize();
 		//cRect2f TileRect = cRect2f(0, 0, fTileSize, fTileSize);
 
 		for (int i = 0; i < mpWorld->GetTileMap()->GetTileLayerNum(); i++) {

--- a/engines/hpl1/engine/sound/SoundHandler.cpp
+++ b/engines/hpl1/engine/sound/SoundHandler.cpp
@@ -732,7 +732,7 @@ void cSoundHandler::UpdateDistanceVolume3D(cSoundEntry *apEntry, float afTimeSte
 			// Log(" max distance ");
 		} else {
 			float fVolume = 0;
-			bool bBlocked = false;
+			//bool bBlocked = false;
 
 			////////////////////////////////////////
 			// Check if sound is blocked.
@@ -759,7 +759,7 @@ void cSoundHandler::UpdateDistanceVolume3D(cSoundEntry *apEntry, float afTimeSte
 					}
 
 					pSound->SetFiltering(true, 0xF);
-					bBlocked = true;
+					//bBlocked = true;
 				} else {
 					// pSound->SetFiltering(false, 0xF);
 

--- a/engines/hpl1/penumbra-overture/Player.cpp
+++ b/engines/hpl1/penumbra-overture/Player.cpp
@@ -975,7 +975,7 @@ public:
 cTempCheckProxy gTempCheckProxy;
 
 void cPlayer::Update(float afTimeStep) {
-	cSystem *pSystem = mpInit->mpGame->GetSystem();
+	//cSystem *pSystem = mpInit->mpGame->GetSystem();
 	//unsigned int lTime = pSystem->GetLowLevel()->getTime();
 	iPhysicsWorld *pPhysicsWorld = mpScene->GetWorld3D()->GetPhysicsWorld();
 

--- a/engines/hpl1/penumbra-overture/PlayerState_Interact.cpp
+++ b/engines/hpl1/penumbra-overture/PlayerState_Interact.cpp
@@ -895,8 +895,8 @@ bool cPlayerState_Push::OnMoveForwards(float afMul, float afTimeStep) {
 
 			if (bCollide) {
 				cVector3f vPos = mpPlayer->GetCharacterBody()->GetPosition();
-				cVector3f vOldPos = vPos;
-				cVector3f vNewPos;
+				//cVector3f vOldPos = vPos;
+				//cVector3f vNewPos;
 				vPos += mvForward * -1 * (fPosAdd + 0.1f);
 				mpPlayer->GetCharacterBody()->SetPosition(vPos);
 


### PR DESCRIPTION
@grisenti : Even more fixes :)

This solves all of the -Wunused-variable and -Wunused-but-set-variable GCC warnings present in the codebase currently. Will look at fixing various other warning classes i.e. shadowing and implicit fallthrough at the top of the list.

By fixing these warnings, it becomes easier to spot "real" problems, mistakes, cut and paste errors during refactoring without the ton of false positives and other cruft making it hard to real issues.

One further note, I know you are still refactoring, but it is generally a good idea to avoid too much commented out code in the codebase as it makes it hard to spot the active code so best to cleanup at some point and rely on the git commit history to revert if there are issues or you need to check an earlier code state i.e. for regression bisection. If you do retain large blocks, then a preprocessor "#if 0" guard tends to be more readable. Note that this is a guideline so mileage varies on the ScummVM codebase :)